### PR TITLE
Implement UserRepository.UpdateByID and .DeleteByID

### DIFF
--- a/internal/repository/postgres/user_repository.go
+++ b/internal/repository/postgres/user_repository.go
@@ -13,9 +13,12 @@ import (
 )
 
 var (
-	ErrUserExists   = errors.New("user already exists")
-	ErrUserNotFound = errors.New("user not found")
-	ErrNoUsersFound = errors.New("no users found")
+	ErrUserExists                = errors.New("user already exists")
+	ErrUserNotFound              = errors.New("user not found")
+	ErrNoUsersFound              = errors.New("no users found")
+	ErrUserUniqueViolation       = errors.New("violated unique constraint")
+	ErrUserNullViolation         = errors.New("violated not null constraint")
+	ErrNonexistentUserPrimaryKey = errors.New("nonexistent user primary key")
 
 	errGenerateUserId = errors.New("failed to generate user id")
 )
@@ -272,9 +275,53 @@ func (r *UserRepository) SelectByName(ctx context.Context, name string) ([]domai
 	return users, nil
 }
 
+const updateUserByIdQuery = `
+UPDATE users SET name = $1, email = $2, password = $3, updated_at = $4
+WHERE id = $5
+`
+
 func (r *UserRepository) UpdateByID(ctx context.Context, user *domain.User) error {
-	// TODO implement me
-	panic("implement me")
+	var dto updateUserByIdDTO
+	dto.FromDomain(user)
+
+	dto.UpdatedAt = time.Now()
+	if err := r.conn.Exec(ctx, updateUserByIdQuery, dto.Name, dto.Email,
+		dto.Password, dto.UpdatedAt, dto.ID); err != nil {
+
+		var pxErr proxerr.Error
+		if errors.As(err, &pxErr) {
+			switch e := pxErr.Unwrap(); {
+			case errors.Is(e, pgdb.ErrUniqueViolation):
+				r.logger.With(log.Fields{
+					"id":    dto.ID,
+					"email": dto.Email,
+				}).Warn("tried to update user with an existing email")
+				return proxerr.New(ErrUserUniqueViolation, err.Error())
+			case errors.Is(e, pgdb.ErrNotNullViolation):
+				r.logger.With(log.Fields{
+					"id":             dto.ID,
+					"name":           dto.Name.String,
+					"email":          dto.Email.String,
+					"password_valid": dto.Password.Valid,
+				}).Warn("tried to update user with null data")
+				return proxerr.New(ErrUserNullViolation, err.Error())
+			case errors.Is(e, pgdb.ErrForeignKeyViolation):
+				r.logger.With(log.Fields{
+					"id": dto.ID,
+				}).Warn("tried to update a nonexistent user")
+				return proxerr.New(ErrNonexistentUserPrimaryKey, err.Error())
+			}
+		}
+
+		r.logger.WithError(err).Error("failed to update user by id")
+		return err
+	}
+
+	r.logger.With(log.Fields{
+		"id": dto.ID,
+	}).Debug("updated user by id")
+	dto.ToDomain(user)
+	return nil
 }
 
 func (r *UserRepository) DeleteByID(ctx context.Context, id string) error {

--- a/internal/repository/postgres/user_repository_dto.go
+++ b/internal/repository/postgres/user_repository_dto.go
@@ -140,3 +140,13 @@ func (dto *updateUserByIdDTO) FromDomain(user *domain.User) {
 		dto.Password = pgtype.Text{String: user.Password, Valid: true}
 	}
 }
+
+type deleteUserByIdDTO struct {
+	ID string `db:"id"`
+}
+
+func (dto *deleteUserByIdDTO) ToDomain(_ *domain.User) {}
+
+func (dto *deleteUserByIdDTO) FromDomain(user *domain.User) {
+	dto.ID = user.ID
+}

--- a/internal/repository/postgres/user_repository_dto.go
+++ b/internal/repository/postgres/user_repository_dto.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"github.com/adanyl0v/pocket-ideas/internal/domain"
+	"github.com/jackc/pgx/v5/pgtype"
 	"time"
 )
 
@@ -112,4 +113,30 @@ func (dto *selectUsersByNameDTO) ToDomain(user *domain.User) {
 
 func (dto *selectUsersByNameDTO) FromDomain(user *domain.User) {
 	dto.Name = user.Name
+}
+
+type updateUserByIdDTO struct {
+	ID        string      `db:"id"`
+	Name      pgtype.Text `db:"name"`
+	Email     pgtype.Text `db:"email"`
+	Password  pgtype.Text `db:"password"`
+	UpdatedAt time.Time   `db:"updated_at"`
+}
+
+func (dto *updateUserByIdDTO) ToDomain(user *domain.User) {
+	user.UpdatedAt = dto.UpdatedAt
+}
+
+func (dto *updateUserByIdDTO) FromDomain(user *domain.User) {
+	dto.ID = user.ID
+
+	if user.Name != "" {
+		dto.Name = pgtype.Text{String: user.Name, Valid: true}
+	}
+	if user.Email != "" {
+		dto.Email = pgtype.Text{String: user.Email, Valid: true}
+	}
+	if user.Password != "" {
+		dto.Password = pgtype.Text{String: user.Password, Valid: true}
+	}
 }

--- a/internal/repository/postgres/user_repository_test.go
+++ b/internal/repository/postgres/user_repository_test.go
@@ -35,7 +35,7 @@ func TestNewUserRepository(t *testing.T) {
 }
 
 func TestUserRepository_Begin(t *testing.T) {
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
 			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				tx := _pgdbMock.NewMockTx(ctrl)
@@ -63,7 +63,7 @@ func TestUserRepository_Begin(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})
@@ -96,7 +96,7 @@ func TestUserRepository_WithTx(t *testing.T) {
 }
 
 func TestUserRepository_Create(t *testing.T) {
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
 			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, idGen *_uuidMock.MockGenerator) {
 				idGen.EXPECT().NewV7().Times(1).Return("", nil)
@@ -151,7 +151,7 @@ func TestUserRepository_Create(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})
@@ -159,7 +159,7 @@ func TestUserRepository_Create(t *testing.T) {
 }
 
 func TestUserRepository_GetByID(t *testing.T) {
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
 			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				row := _pgdbMock.NewMockRow(ctrl)
@@ -207,7 +207,7 @@ func TestUserRepository_GetByID(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})
@@ -215,7 +215,7 @@ func TestUserRepository_GetByID(t *testing.T) {
 }
 
 func TestUserRepository_GetByEmail(t *testing.T) {
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
 			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				row := _pgdbMock.NewMockRow(ctrl)
@@ -263,7 +263,7 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})
@@ -271,7 +271,7 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 }
 
 func TestUserRepository_SelectAll(t *testing.T) {
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
 			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				rows := _pgdbMock.NewMockRows(ctrl)
@@ -358,7 +358,7 @@ func TestUserRepository_SelectAll(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})
@@ -366,7 +366,7 @@ func TestUserRepository_SelectAll(t *testing.T) {
 }
 
 func TestUserRepository_SelectByName(t *testing.T) {
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
 			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				rows := _pgdbMock.NewMockRows(ctrl)
@@ -454,7 +454,7 @@ func TestUserRepository_SelectByName(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})
@@ -469,9 +469,9 @@ func TestUserRepository_UpdateByID(t *testing.T) {
 		Password: "password",
 	}
 
-	testCases := map[string]userTc{
+	tcs := map[string]userTc{
 		"success": {
-			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				conn.EXPECT().Exec(gomock.Any(), updateUserByIdQuery, gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 			},
@@ -483,7 +483,7 @@ func TestUserRepository_UpdateByID(t *testing.T) {
 			},
 		},
 		"unique violation": {
-			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				conn.EXPECT().Exec(gomock.Any(), updateUserByIdQuery, gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any()).Times(1).Return(proxerr.New(pgdb.ErrUniqueViolation, ""))
 			},
@@ -495,7 +495,7 @@ func TestUserRepository_UpdateByID(t *testing.T) {
 			},
 		},
 		"not null violation": {
-			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				conn.EXPECT().Exec(gomock.Any(), updateUserByIdQuery, gomock.Any(), gomock.Any(),
 					pgtype.Text{String: "", Valid: false}, gomock.Any(), gomock.Any()).Times(1).
 					Return(proxerr.New(pgdb.ErrNotNullViolation, ""))
@@ -513,7 +513,7 @@ func TestUserRepository_UpdateByID(t *testing.T) {
 			},
 		},
 		"foreign key violation": {
-			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				conn.EXPECT().Exec(gomock.Any(), updateUserByIdQuery, gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), "").Times(1).Return(proxerr.New(pgdb.ErrForeignKeyViolation, ""))
 			},
@@ -530,7 +530,7 @@ func TestUserRepository_UpdateByID(t *testing.T) {
 			},
 		},
 		"failure": {
-			register: func(ctrl *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
 				conn.EXPECT().Exec(gomock.Any(), updateUserByIdQuery, gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any()).Times(1).Return(errors.New(""))
 			},
@@ -543,7 +543,53 @@ func TestUserRepository_UpdateByID(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			runUserTestCase(t, &tc)
+		})
+	}
+}
+
+func TestUserRepository_DeleteByID(t *testing.T) {
+	tcs := map[string]userTc{
+		"success": {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+				conn.EXPECT().Exec(gomock.Any(), deleteUserByIdQuery, gomock.Any()).Times(1).Return(nil)
+			},
+			command: func(repo *UserRepository) error {
+				return repo.DeleteByID(context.Background(), "")
+			},
+			expect: func(err error) {
+				require.Nil(t, err)
+			},
+		},
+		"foreign key violation": {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+				conn.EXPECT().Exec(gomock.Any(), deleteUserByIdQuery, gomock.Any()).Times(1).
+					Return(proxerr.New(pgdb.ErrForeignKeyViolation, ""))
+			},
+			command: func(repo *UserRepository) error {
+				return repo.DeleteByID(context.Background(), "")
+			},
+			expect: func(err error) {
+				require.Equal(t, ErrNonexistentUserPrimaryKey, err)
+			},
+		},
+		"failure": {
+			register: func(_ *gomock.Controller, conn *_pgdbMock.MockConn, _ *_uuidMock.MockGenerator) {
+				conn.EXPECT().Exec(gomock.Any(), deleteUserByIdQuery, gomock.Any()).Times(1).
+					Return(errors.New(""))
+			},
+			command: func(repo *UserRepository) error {
+				return repo.DeleteByID(context.Background(), "")
+			},
+			expect: func(err error) {
+				require.NotNil(t, err)
+			},
+		},
+	}
+
+	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			runUserTestCase(t, &tc)
 		})


### PR DESCRIPTION
This PR implements the `UserRepository.UpdateByID()` and `UserRepository.DeleteByID()` methods.
It also makes a bit of refactor, renaming all `testCases` variables to `tcs`.

**100% test coverage**