### PR TITLE
Add a Redis Adapter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,3 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
 
 on:

--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -12,3 +12,6 @@ postgres:
   max_conn_lifetime: 60m
   max_conn_idle_time: 30m
   health_check_period: 1m
+
+redis:
+  dial_timeout: 5s

--- a/configs/redis/redis.conf
+++ b/configs/redis/redis.conf
@@ -1,0 +1,31 @@
+# Basic configuration
+bind 0.0.0.0
+
+# Persistence
+appendonly yes
+appendfilename "appendonly.aof"
+
+# Memory management
+maxmemory 512mb
+maxmemory-policy allkeys-lru
+
+# Security
+protected-mode no
+requirepass $REDIS_PASSWORD
+
+# Disable dangerous commands
+#rename-command FLUSHALL ""
+#rename-command FLUSHDB ""
+#rename-command CONFIG ""
+#rename-command SHUTDOWN ""
+#rename-command KEYS ""
+#rename-command DEBUG ""
+#rename-command SAVE ""
+#rename-command BGSAVE ""
+#rename-command BGREWRITEAOF ""
+#rename-command MIGRATE ""
+#rename-command RESTORE ""
+#rename-command SORT ""
+#rename-command MONITOR ""
+#rename-command SYNC ""
+#rename-command PSYNC ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,5 +38,35 @@ services:
     healthcheck:
       test: ['CMD', 'pg_isready', '-h', 'localhost']
 
+  redis-1:
+    image: redis:alpine
+    container_name: redis-1
+    ports:
+      - '${REDIS_OUTER_PORT}:${REDIS_INNER_PORT}'
+    environment:
+      REDIS_USER: '${REDIS_USER}'
+      REDIS_USER_PASSWORD: '${REDIS_USER_PASSWORD}'
+      REDIS_PASSWORD: '${REDIS_PASSWORD}'
+    command: >
+      sh -c '
+        mkdir -p /usr/local/etc/redis &&
+        echo "bind 0.0.0.0" > /usr/local/etc/redis/redis.conf &&
+        echo "requirepass $REDIS_PASSWORD" >> /usr/local/etc/redis/redis.conf &&
+        echo "appendonly yes" >> /usr/local/etc/redis/redis.conf &&
+        echo "appendfsync everysec" >> /usr/local/etc/redis/redis.conf &&
+        echo "user default on nopass ~* +@all" > /usr/local/etc/redis/users.acl &&
+        echo "user $REDIS_USER on >$REDIS_USER_PASSWORD ~* +@all" >> /usr/local/etc/redis/users.acl
+        redis-server /usr/local/etc/redis/redis.conf --aclfile /usr/local/etc/redis/users.acl
+      '
+    volumes:
+      - redis_1_data:/var/lib/redis/data
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "redis-cli", "-a", "$REDIS_PASSWORD", "ping" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 volumes:
   postgres_data:
+  redis_1_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ['CMD-SHELL', 'pg_isready', '-U', '${POSTGRES_USER}', '-d', '${POSTGRES_DATABASE}']
       interval: 5s
       timeout: 5s
       retries: 5
@@ -38,35 +38,31 @@ services:
     healthcheck:
       test: ['CMD', 'pg_isready', '-h', 'localhost']
 
-  redis-1:
-    image: redis:alpine
-    container_name: redis-1
+  redis:
+    image: redis/redis-stack:latest
+    container_name: redis-stack
     ports:
-      - '${REDIS_OUTER_PORT}:${REDIS_INNER_PORT}'
+      - '${REDIS_CONTAINER_OUTER_PORT}:${REDIS_CONTAINER_INNER_PORT}'
     environment:
       REDIS_USER: '${REDIS_USER}'
       REDIS_USER_PASSWORD: '${REDIS_USER_PASSWORD}'
       REDIS_PASSWORD: '${REDIS_PASSWORD}'
+    volumes:
+      - redis_data:/var/lib/redis/data
+      - ./configs/redis/redis.conf:/usr/local/etc/redis/redis.conf
+    restart: always
     command: >
       sh -c '
-        mkdir -p /usr/local/etc/redis &&
-        echo "bind 0.0.0.0" > /usr/local/etc/redis/redis.conf &&
-        echo "requirepass $REDIS_PASSWORD" >> /usr/local/etc/redis/redis.conf &&
-        echo "appendonly yes" >> /usr/local/etc/redis/redis.conf &&
-        echo "appendfsync everysec" >> /usr/local/etc/redis/redis.conf &&
-        echo "user default on nopass ~* +@all" > /usr/local/etc/redis/users.acl &&
-        echo "user $REDIS_USER on >$REDIS_USER_PASSWORD ~* +@all" >> /usr/local/etc/redis/users.acl
+        echo "user default off" > /usr/local/etc/redis/users.acl
+        echo "user $REDIS_USER on ~* +@all >$REDIS_USER_PASSWORD" >> /usr/local/etc/redis/users.acl
         redis-server /usr/local/etc/redis/redis.conf --aclfile /usr/local/etc/redis/users.acl
       '
-    volumes:
-      - redis_1_data:/var/lib/redis/data
-    restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "redis-cli", "-a", "$REDIS_PASSWORD", "ping" ]
+      test: [ 'CMD', 'redis-cli', '-a', '$REDIS_PASSWORD', 'ping' ]
       interval: 5s
       timeout: 5s
       retries: 5
 
 volumes:
   postgres_data:
-  redis_1_data:
+  redis_data:

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,15 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/nitishm/go-rejson/v4 v4.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.7.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/samber/slog-common v0.18.1 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/adanyl0v/pocket-ideas/internal/config"
 	"github.com/adanyl0v/pocket-ideas/internal/repository/postgres"
+	"github.com/adanyl0v/pocket-ideas/pkg/cache/redis"
 	"github.com/adanyl0v/pocket-ideas/pkg/database/postgres/pgx"
 	"github.com/adanyl0v/pocket-ideas/pkg/log"
 	"github.com/adanyl0v/pocket-ideas/pkg/log/slog"
@@ -17,15 +18,16 @@ import (
 	"path/filepath"
 )
 
-var logger log.Logger
-
 func Run() {
 	cfg := config.MustReadFile(config.DefaultFilePath())
-	logger = mustSetupLogger(cfg.Env, &cfg.Log)
+	logger := mustSetupLogger(cfg.Env, &cfg.Log)
 	logger.With(log.Fields{"env": cfg.Env}).Info("read config")
 
 	db := mustConnectToPostgres(logger, &cfg.PostgresConfig)
 	defer func() { _ = db.Close() }()
+
+	redisCache := mustConnectToRedis(logger, &cfg.RedisConfig)
+	defer func() { _ = redisCache.Close() }()
 
 	userRepo := postgres.NewUserRepository(db, logger, googleuuidgen.New())
 	_ = userRepo
@@ -71,7 +73,7 @@ func mustSetupLogger(env string, cfg *config.LogConfig) log.Logger {
 			FunctionKey:    "@FUNCTION",
 			StacktraceKey:  "@STACKTRACE",
 			EncodeLevel:    zapcore.CapitalColorLevelEncoder,
-			EncodeTime:     zapcore.TimeEncoderOfLayout("2006-01-02 15:04:05"),
+			EncodeTime:     zapcore.TimeEncoderOfLayout("02/01/2006 15:04:05"),
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller: func(caller zapcore.EntryCaller, encoder zapcore.PrimitiveArrayEncoder) {
 				cwd, _ := os.Getwd()
@@ -141,4 +143,24 @@ func mustConnectToPostgres(logger log.Logger, cfg *config.PostgresConfig) *pgx.D
 
 	logger.Info("connected to postgres")
 	return db
+}
+
+func mustConnectToRedis(logger log.Logger, cfg *config.RedisConfig) *redis.Client {
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.DialTimeout)
+	defer cancel()
+
+	client, err := redis.Connect(ctx, logger, &redis.Config{
+		Host:        cfg.Host,
+		Port:        cfg.Port,
+		User:        cfg.User,
+		Password:    cfg.Password,
+		Database:    cfg.Database,
+		DialTimeout: cfg.DialTimeout,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Info("connected to redis")
+	return client
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,10 +42,17 @@ type PostgresConfig struct {
 }
 
 type RedisConfig struct {
-	Host        string        `yaml:"host" env:"REDIS_HOST" env-required:"true"`
-	Port        int           `yaml:"port" env:"REDIS_OUTER_PORT" env-required:"true"`
-	User        string        `yaml:"user" env:"REDIS_USER" env-required:"true"`
-	Password    string        `yaml:"password" env:"REDIS_USER_PASSWORD" env-required:"true"`
-	Database    int           `yaml:"database" env:"REDIS_DATABASE" env-default:"0"`
-	DialTimeout time.Duration `yaml:"dial_timeout" env:"REDIS_DIAL_TIMEOUT" env-default:"5s"`
+	Host            string        `yaml:"host" env:"REDIS_HOST" env-required:"true"`
+	Port            int           `yaml:"port" env:"REDIS_PORT" env-required:"true"`
+	User            string        `yaml:"user" env:"REDIS_USER" env-required:"true"`
+	Password        string        `yaml:"password" env:"REDIS_USER_PASSWORD" env-required:"true"`
+	Database        int           `yaml:"database" env:"REDIS_DATABASE" env-default:"0"`
+	DialTimeout     time.Duration `yaml:"dial_timeout" env:"REDIS_DIAL_TIMEOUT" env-default:"5s"`
+	ReadTimeout     time.Duration `yaml:"read_timeout" env:"REDIS_READ_TIMEOUT" env-default:"3s"`
+	WriteTimeout    time.Duration `yaml:"write_timeout" env:"REDIS_WRITE_TIMEOUT" env-default:"3s"`
+	MinIdleConns    int           `yaml:"min_idle_conns" env:"REDIS_MIN_IDLE_CONNS" env-default:"0"`
+	MaxIdleConns    int           `yaml:"max_idle_conns" env:"REDIS_MAX_IDLE_CONNS" env-default:"0"`
+	MaxActiveConns  int           `yaml:"max_active_conns" env:"REDIS_MAX_ACTIVE_CONNS" env-default:"0"`
+	ConnMaxIdleTime time.Duration `yaml:"conn_max_idle_time" env:"REDIS_CONN_MAX_IDLE_TIME" env-default:"30m"`
+	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime" env:"REDIS_CONN_MAX_LIFETIME" env-default:"0"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Env            string         `yaml:"env" env:"ENV" env-required:"true"`
 	Log            LogConfig      `yaml:"log"`
 	PostgresConfig PostgresConfig `yaml:"postgres"`
+	RedisConfig    RedisConfig    `yaml:"redis"`
 }
 
 type LogConfig struct {
@@ -38,4 +39,13 @@ type PostgresConfig struct {
 	MaxConnLifetime   time.Duration `yaml:"max_conn_lifetime" env:"POSTGRES_MAX_CONN_LIFETIME" env-default:"60m"`
 	MaxConnIdleTime   time.Duration `yaml:"max_conn_idle_time" env:"POSTGRES_MAX_CONN_IDLE_TIME" env-default:"30m"`
 	HealthCheckPeriod time.Duration `yaml:"health_check_period" env:"POSTGRES_HEALTH_CHECK_PERIOD" env-default:"1m"`
+}
+
+type RedisConfig struct {
+	Host        string        `yaml:"host" env:"REDIS_HOST" env-required:"true"`
+	Port        int           `yaml:"port" env:"REDIS_OUTER_PORT" env-required:"true"`
+	User        string        `yaml:"user" env:"REDIS_USER" env-required:"true"`
+	Password    string        `yaml:"password" env:"REDIS_USER_PASSWORD" env-required:"true"`
+	Database    int           `yaml:"database" env:"REDIS_DATABASE" env-default:"0"`
+	DialTimeout time.Duration `yaml:"dial_timeout" env:"REDIS_DIAL_TIMEOUT" env-default:"5s"`
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,19 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+type Cache interface {
+	Get(ctx context.Context, key string) (Scannable, error)
+	GetJSON(ctx context.Context, key, path string) (Scannable, error)
+	Set(ctx context.Context, key string, value any, expiration time.Duration) error
+	SetJSON(ctx context.Context, key, path string, value any, expiration time.Duration) error
+	Delete(ctx context.Context, keys ...string) error
+	DeleteJSON(ctx context.Context, key, path string) error
+}
+
+type Scannable interface {
+	Scan(dest any) error
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6,14 +6,10 @@ import (
 )
 
 type Cache interface {
-	Get(ctx context.Context, key string) (Scannable, error)
-	GetJSON(ctx context.Context, key, path string) (Scannable, error)
+	Get(ctx context.Context, key string, dest any) error
+	GetJSON(ctx context.Context, key, path string, dest any) error
 	Set(ctx context.Context, key string, value any, expiration time.Duration) error
 	SetJSON(ctx context.Context, key, path string, value any, expiration time.Duration) error
 	Delete(ctx context.Context, keys ...string) error
 	DeleteJSON(ctx context.Context, key, path string) error
-}
-
-type Scannable interface {
-	Scan(dest any) error
 }

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -3,11 +3,22 @@ package redis
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/adanyl0v/pocket-ideas/pkg/log"
-	"github.com/nitishm/go-rejson/v4"
+	"github.com/adanyl0v/pocket-ideas/pkg/proxerr"
 	"github.com/redis/go-redis/v9"
 	"time"
+)
+
+var (
+	ErrNonexistentKey = errors.New("the key does not exist")
+)
+
+const (
+	Root = "$"
+	Keep = redis.KeepTTL
 )
 
 type Config struct {
@@ -29,20 +40,130 @@ type Config struct {
 
 type Client struct {
 	client *redis.Client
-	rejson rejson.ReJSON
 	logger log.Logger
 }
 
-func New(client *redis.Client, rejson rejson.ReJSON, logger log.Logger) *Client {
+func New(client *redis.Client, logger log.Logger) *Client {
 	return &Client{
 		client: client,
-		rejson: rejson,
 		logger: logger,
 	}
 }
 
 func (c *Client) Close() error {
-	return c.client.Close()
+	if err := c.client.Close(); err != nil {
+		c.logger.WithError(err).Debug("failed to close the redis connection")
+		return err
+	}
+
+	c.logger.Debug("closed the redis connection")
+	return nil
+}
+
+func (c *Client) Get(ctx context.Context, key string, dest any) error {
+	logger := c.logger.With(log.Fields{"key": key})
+
+	cmd := c.client.Get(ctx, key)
+	if err := cmd.Err(); err != nil {
+		if errors.Is(err, redis.Nil) {
+			logger.WithError(err).Debug("key does not exist")
+			return proxerr.New(ErrNonexistentKey, err.Error())
+		}
+
+		logger.WithError(err).Debug("failed to get the key")
+		return err
+	}
+
+	logger.Debug("got the key")
+	return cmd.Scan(dest)
+}
+
+func (c *Client) GetJSON(ctx context.Context, key, path string, dest any) error {
+	logger := c.logger.With(log.Fields{
+		"key":  key,
+		"path": path,
+	})
+
+	cmd := c.client.JSONGet(ctx, key, path)
+	if err := cmd.Err(); err != nil {
+		if errors.Is(err, redis.Nil) {
+			logger.WithError(err).Debug("key does not exist")
+			return proxerr.New(ErrNonexistentKey, err.Error())
+		}
+
+		logger.WithError(err).Debug("failed to get the key")
+		return err
+	}
+
+	logger.Debug("got the key")
+	return json.Unmarshal([]byte(cmd.String()), dest)
+}
+
+func (c *Client) Set(ctx context.Context, key string, value any, expiration time.Duration) error {
+	logger := c.logger.With(log.Fields{
+		"key": key,
+		"exp": expiration,
+	})
+
+	cmd := c.client.Set(ctx, key, value, expiration)
+	if err := cmd.Err(); err != nil {
+		logger.WithError(err).Debug("failed to set the key")
+		return err
+	}
+
+	logger.Debug("set the key")
+	return nil
+}
+
+func (c *Client) SetJSON(ctx context.Context, key, path string, value any, expiration time.Duration) error {
+	logger := c.logger.With(log.Fields{
+		"key":  key,
+		"path": path,
+		"exp":  expiration,
+	})
+
+	cmd := c.client.JSONSet(ctx, key, path, value)
+	if err := cmd.Err(); err != nil {
+		logger.WithError(err).Debug("failed to set the key")
+		return err
+	}
+
+	if err := c.client.Expire(ctx, key, expiration).Err(); err != nil {
+		logger.WithError(err).Debug("failed to expire the key")
+		return err
+	}
+
+	logger.Debug("set the key")
+	return nil
+}
+
+func (c *Client) Delete(ctx context.Context, keys ...string) error {
+	logger := c.logger.With(log.Fields{"keys": keys})
+
+	cmd := c.client.Del(ctx, keys...)
+	if err := cmd.Err(); err != nil {
+		logger.WithError(err).Debug("failed to delete the keys")
+		return err
+	}
+
+	logger.Debug("deleted the keys")
+	return nil
+}
+
+func (c *Client) DeleteJSON(ctx context.Context, key, path string) error {
+	logger := c.logger.With(log.Fields{
+		"key":  key,
+		"path": path,
+	})
+
+	cmd := c.client.JSONDel(ctx, key, path)
+	if err := cmd.Err(); err != nil {
+		logger.WithError(err).Debug("failed to delete the key")
+		return err
+	}
+
+	logger.Debug("deleted the key")
+	return nil
 }
 
 func Connect(ctx context.Context, logger log.Logger, config *Config) (*Client, error) {
@@ -61,10 +182,21 @@ func Connect(ctx context.Context, logger log.Logger, config *Config) (*Client, e
 		ConnMaxLifetime: config.ConnMaxLifetime,
 		TLSConfig:       config.TLSConfig,
 	}
+	logger.With(log.Fields{
+		"addr":          opts.Addr,
+		"database":      opts.DB,
+		"dial_timeout":  opts.DialTimeout,
+		"read_timeout":  opts.ReadTimeout,
+		"write_timeout": opts.WriteTimeout,
+	}).Debug("parsed the redis connection config")
+
 	client := redis.NewClient(&opts)
 	logger.With(log.Fields{
-		"addr":     opts.Addr,
-		"database": opts.DB,
+		"min_idle_conns":     opts.MinIdleConns,
+		"max_idle_conns":     opts.MaxIdleConns,
+		"max_active_conns":   opts.MaxActiveConns,
+		"conn_max_idle_time": opts.ConnMaxIdleTime,
+		"conn_max_lifetime":  opts.ConnMaxLifetime,
 	}).Debug("created a new redis client")
 
 	_, err := client.Ping(ctx).Result()
@@ -73,9 +205,14 @@ func Connect(ctx context.Context, logger log.Logger, config *Config) (*Client, e
 		return nil, err
 	}
 
-	logger.Debug("pinged the redis connection")
-
-	rh := rejson.NewReJSONHandler()
-	rh.SetGoRedisClientWithContext(ctx, client)
-	return New(client, rh, logger), nil
+	stats := client.PoolStats()
+	logger.With(log.Fields{
+		"hits":        stats.Hits,
+		"misses":      stats.Misses,
+		"timeouts":    stats.Timeouts,
+		"total_conns": stats.TotalConns,
+		"idle_conns":  stats.IdleConns,
+		"stale_conns": stats.StaleConns,
+	}).Debug("pinged the redis connection")
+	return New(client, logger), nil
 }

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -1,0 +1,81 @@
+package redis
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/adanyl0v/pocket-ideas/pkg/log"
+	"github.com/nitishm/go-rejson/v4"
+	"github.com/redis/go-redis/v9"
+	"time"
+)
+
+type Config struct {
+	Host            string
+	Port            int
+	User            string
+	Password        string
+	Database        int
+	DialTimeout     time.Duration
+	ReadTimeout     time.Duration
+	WriteTimeout    time.Duration
+	MaxIdleConns    int
+	MinIdleConns    int
+	MaxActiveConns  int
+	ConnMaxIdleTime time.Duration
+	ConnMaxLifetime time.Duration
+	TLSConfig       *tls.Config
+}
+
+type Client struct {
+	client *redis.Client
+	rejson rejson.ReJSON
+	logger log.Logger
+}
+
+func New(client *redis.Client, rejson rejson.ReJSON, logger log.Logger) *Client {
+	return &Client{
+		client: client,
+		rejson: rejson,
+		logger: logger,
+	}
+}
+
+func (c *Client) Close() error {
+	return c.client.Close()
+}
+
+func Connect(ctx context.Context, logger log.Logger, config *Config) (*Client, error) {
+	opts := redis.Options{
+		Addr:            fmt.Sprintf("%s:%d", config.Host, config.Port),
+		Username:        config.User,
+		Password:        config.Password,
+		DB:              config.Database,
+		DialTimeout:     config.DialTimeout,
+		ReadTimeout:     config.ReadTimeout,
+		WriteTimeout:    config.WriteTimeout,
+		MinIdleConns:    config.MinIdleConns,
+		MaxIdleConns:    config.MaxIdleConns,
+		MaxActiveConns:  config.MaxActiveConns,
+		ConnMaxIdleTime: config.ConnMaxIdleTime,
+		ConnMaxLifetime: config.ConnMaxLifetime,
+		TLSConfig:       config.TLSConfig,
+	}
+	client := redis.NewClient(&opts)
+	logger.With(log.Fields{
+		"addr":     opts.Addr,
+		"database": opts.DB,
+	}).Debug("created a new redis client")
+
+	_, err := client.Ping(ctx).Result()
+	if err != nil {
+		logger.WithError(err).Error("failed to ping the redis connection")
+		return nil, err
+	}
+
+	logger.Debug("pinged the redis connection")
+
+	rh := rejson.NewReJSONHandler()
+	rh.SetGoRedisClientWithContext(ctx, client)
+	return New(client, rh, logger), nil
+}

--- a/pkg/database/postgres/pgx/database.go
+++ b/pkg/database/postgres/pgx/database.go
@@ -109,6 +109,7 @@ func Connect(ctx context.Context, config *Config, logger log.Logger) (*DB, error
 
 func (db *DB) Close() error {
 	db.pool.Close()
+	db.logger.Debug("closed the postgres connection")
 	return nil
 }
 

--- a/pkg/database/postgres/pgx/database.go
+++ b/pkg/database/postgres/pgx/database.go
@@ -65,7 +65,7 @@ func Connect(ctx context.Context, config *Config, logger log.Logger) (*DB, error
 		"port":     config.Port,
 		"database": config.Database,
 		"sslmode":  config.SSLMode,
-	}).Debug("parsed the connection config")
+	}).Debug("parsed the postgres connection config")
 
 	c.MaxConns = int32(config.MaxConns)
 	c.MinConns = int32(config.MinConns)
@@ -81,7 +81,7 @@ func Connect(ctx context.Context, config *Config, logger log.Logger) (*DB, error
 
 	pool, err := pgxpool.NewWithConfig(ctx, c)
 	if err != nil {
-		logger.WithError(err).Error("failed to create a new connection pool")
+		logger.WithError(err).Error("failed to create a new postgres connection pool")
 		return nil, err
 	}
 	logger.With(log.Fields{
@@ -90,10 +90,10 @@ func Connect(ctx context.Context, config *Config, logger log.Logger) (*DB, error
 		"max_conn_lifetime":   c.MaxConnLifetime,
 		"max_conn_idle_time":  c.MaxConnIdleTime,
 		"health_check_period": c.HealthCheckPeriod,
-	}).Debug("created a new connection pool")
+	}).Debug("created a new postgres connection pool")
 
 	if err = pool.Ping(ctx); err != nil {
-		logger.WithError(err).Error("failed to ping the connection")
+		logger.WithError(err).Error("failed to ping the postgres connection")
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func Connect(ctx context.Context, config *Config, logger log.Logger) (*DB, error
 		"acquired_total": stat.AcquireCount(),
 		"acquired_now":   stat.AcquiredConns(),
 		"acquired_empty": stat.EmptyAcquireCount(),
-	}).Debug("pinged the connection")
+	}).Debug("pinged the postgres connection")
 
 	return New(pool, logger.WithCallerSkip(1)), nil
 }


### PR DESCRIPTION
This PR sets up the Redis docker-compose service and implements the cache interface. It also renames the `ci.yml` Golang workflow file to `go.yml` and refactors debug logging messages a bit.

The adapter implementation connects to the Redis container and performs basic `Get`, `Set`, `Delete` operations, using the [go-redis](https://github.com/redis/go-redis) client. It also supports working with JSON.

Redis is planned to be used in the future to store JWT sessions, as well as whitelists and blacklists of access and refresh tokens, respectively.